### PR TITLE
Update text_analytics.py

### DIFF
--- a/text_analytics/text_analytics.py
+++ b/text_analytics/text_analytics.py
@@ -1,5 +1,5 @@
 #General imports
-from collections import Mapping
+from collections.abc import Mapping
 from collections import defaultdict
 from functools import partial
 import warnings


### PR DESCRIPTION
This pull request addresses a compatibility issue with Python 3.9 and above, where importing `Mapping` directly from `collections` results in an `ImportError`. To ensure compatibility across all supported Python versions, this change updates the import statement to fetch `Mapping` from `collections.abc` instead.